### PR TITLE
Add job notifier service

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This system is designed around the following microservices:
 | **profile-manager** | Stores and manages user job preferences                                |
 | **job-fetcher**    | Scrapes or fetches jobs from external sources and scores them           |
 | **job-matcher**    | Matches jobs to users using a smart algorithm                           |
+| **job-notifier**    | Sends daily email summaries with cover letters |
 
 All services communicate via **Google Cloud Pub/Sub**, enabling full decoupling, scalability, and asynchronous processing.
 
@@ -63,6 +64,7 @@ services/
   profile-manager/       # Job preference storage and management
   job-fetcher/           # Job ingestion/scraping logic
   job-matcher/           # (Planned) Matching engine based on preferences
+  job-notifier/        # Sends daily job emails with cover letters
 
 pubsub/
   publisher.ts           # Event publisher utility (e.g. publishCvUploaded)
@@ -101,6 +103,11 @@ OPENAI_API_KEY=your-openrouter-key
 DATABASE_URL=postgres://...
 GCP_PROJECT_ID=your-project
 GOOGLE_APPLICATION_CREDENTIALS=path-to-service-account.json
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=your-smtp-user
+SMTP_PASS=your-smtp-pass
+FROM_EMAIL=noreply@example.com
 ```
 
 ### 3. Migrate DB
@@ -114,6 +121,7 @@ pnpm prisma migrate dev --name init
 ```bash
 pnpm dev
 ```
+This will start **profile-manager**, **job-fetcher**, and **job-notifier** for local development.
 
 ---
 
@@ -124,6 +132,7 @@ pnpm dev
 | `cv-uploaded`  | `{ userId, cvText, timestamp }`     | `cv-parser`  |
 | `jobs-fetched` | `{ jobList: Job[], source }`        | `job-fetcher` |
 | `profile-updated` | `{ userId, preferences }`        | `profile-manager` |
+| `job-matched` | `{ userId, email, jobs }`         | `job-matcher` |
 
 ---
 

--- a/libs/domain-events/src/events/JobMatchedEvent.ts
+++ b/libs/domain-events/src/events/JobMatchedEvent.ts
@@ -1,0 +1,12 @@
+export interface JobInfo {
+  id: string;
+  title: string;
+  company: string;
+  url: string;
+}
+
+export interface JobMatchedEvent {
+  userId: string;
+  email: string;
+  jobs: JobInfo[];
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "concurrently --names \"profile,fetcher\" -c \"green,cyan\" \"pnpm --filter profile-manager dev\" \"pnpm --filter job-fetcher dev\""
+    "dev": "concurrently --names \"profile,fetcher,notifier\" -c \"green,cyan,magenta\" \"pnpm --filter profile-manager dev\" \"pnpm --filter job-fetcher dev\" \"pnpm --filter job-notifier dev\""
   },
   "devDependencies": {
     "@prisma/client": "^6.8.2",

--- a/services/job-notifier/package.json
+++ b/services/job-notifier/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "job-notifier",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "dev": "ts-node-dev src/index.ts"
+  },
+  "dependencies": {
+    "@google-cloud/pubsub": "^5.0.0",
+    "dotenv": "^16.5.0",
+    "node-cron": "^3.0.3",
+    "nodemailer": "^6.9.11",
+    "openai": "^4.103.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.21",
+    "@types/nodemailer": "^6.4.8",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.8.3"
+  }
+}

--- a/services/job-notifier/src/coverLetter.ts
+++ b/services/job-notifier/src/coverLetter.ts
@@ -1,0 +1,16 @@
+import { OpenAI } from 'openai';
+import { JobMatchedEvent } from '../../../libs/domain-events/src/events/JobMatchedEvent';
+
+const { OPENAI_API_KEY } = process.env;
+
+const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
+
+export async function generateCoverLetter(event: JobMatchedEvent): Promise<string> {
+  const job = event.jobs[0];
+  const prompt = `Write a short cover letter for a job application.\nJob title: ${job.title}\nCompany: ${job.company}`;
+  const completion = await openai.chat.completions.create({
+    messages: [{ role: 'user', content: prompt }],
+    model: 'gpt-3.5-turbo'
+  });
+  return completion.choices[0]?.message?.content || '';
+}

--- a/services/job-notifier/src/email.ts
+++ b/services/job-notifier/src/email.ts
@@ -1,0 +1,25 @@
+import nodemailer from 'nodemailer';
+
+const { SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS, FROM_EMAIL } = process.env;
+
+export interface EmailJob {
+  to: string;
+  subject: string;
+  html: string;
+}
+
+export async function sendEmail(job: EmailJob) {
+  const transporter = nodemailer.createTransport({
+    host: SMTP_HOST,
+    port: Number(SMTP_PORT) || 587,
+    secure: false,
+    auth: SMTP_USER && SMTP_PASS ? { user: SMTP_USER, pass: SMTP_PASS } : undefined
+  });
+  await transporter.sendMail({
+    from: FROM_EMAIL,
+    to: job.to,
+    subject: job.subject,
+    html: job.html
+  });
+  console.log('[Email] sent to', job.to);
+}

--- a/services/job-notifier/src/index.ts
+++ b/services/job-notifier/src/index.ts
@@ -1,0 +1,25 @@
+import 'dotenv/config';
+import cron from 'node-cron';
+import { listenForJobMatchedEvents, JobStore } from './subscriber';
+import { generateCoverLetter } from './coverLetter';
+import { sendEmail } from './email';
+
+const store: JobStore = new Map();
+listenForJobMatchedEvents(store);
+
+cron.schedule('0 8 * * *', async () => {
+  for (const [userId, events] of store.entries()) {
+    if (events.length === 0) continue;
+    const latest = events[events.length - 1];
+    const letter = await generateCoverLetter(latest);
+    const jobList = latest.jobs.map(j => `<li><a href="${j.url}">${j.title}</a> at ${j.company}</li>`).join('');
+    await sendEmail({
+      to: latest.email,
+      subject: 'Daily Job Matches',
+      html: `<p>Here are your matched jobs:</p><ul>${jobList}</ul><p>${letter}</p>`
+    });
+    store.set(userId, []);
+  }
+});
+
+console.log('Job notifier running...');

--- a/services/job-notifier/src/subscriber.ts
+++ b/services/job-notifier/src/subscriber.ts
@@ -1,0 +1,19 @@
+import { PubSub } from '@google-cloud/pubsub';
+import { JobMatchedEvent } from '../../../libs/domain-events/src/events/JobMatchedEvent';
+
+export type JobStore = Map<string, JobMatchedEvent[]>;
+
+const pubsub = new PubSub();
+
+export function listenForJobMatchedEvents(store: JobStore) {
+  const subscription = pubsub.subscription('job-matched-sub');
+
+  subscription.on('message', message => {
+    const data = JSON.parse(message.data.toString()) as JobMatchedEvent;
+    const list = store.get(data.userId) || [];
+    list.push(data);
+    store.set(data.userId, list);
+    console.log('[JobMatchedEvent] stored for user', data.userId);
+    message.ack();
+  });
+}

--- a/services/job-notifier/tsconfig.json
+++ b/services/job-notifier/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- include job-notifier in README and folder overview
- define `JobMatchedEvent` interface
- add new `job-notifier` service that listens for job matches
- send daily email with cover letter using cron
- document SMTP environment variables and `job-matched` event
- run job-notifier with other services in dev mode

## Testing
- `npm test` *(fails: Error: no test specified)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_686e91db873c8327b15346129b8d3ae9